### PR TITLE
Add setup scripts and CI pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+NOTION_TOKEN=your_notion_token
+SLACK_BOT_TOKEN=your_slack_bot_token
+SLACK_CHANNEL=#general
+PARENT_PAGE_ID=your_parent_page_id
+GOOGLE_CREDENTIALS_FILE=path/to/service_account.json
+GOOGLE_CALENDAR_ID=primary

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run SaaS script
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          PARENT_PAGE_ID: ${{ secrets.PARENT_PAGE_ID }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          GOOGLE_CREDENTIALS_FILE: credentials.json
+          GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}" > credentials.json
+          python SaaS.py
+
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
-# SaaS
+# SaaS Automation
 
-Project automates Notion database creation and Slack integration.
+This project automates creation of Notion databases and posts status messages to Slack. A Google Calendar integration example is also included.
+
+## Folder Structure
+```
+/.github/workflows  - CI/CD pipeline
+/tests               - pytest tests
+setup.bat            - Windows setup helper
+SaaS.py              - main automation script
+.env.example         - environment variable template
+```
+
+## Quick Start (Windows)
+1. Clone the repository and open a VSCode terminal.
+2. Run `setup.bat`. The script creates/activates `venv`, installs dependencies, copies `.env.example` to `.env` if missing and executes `SaaS.py`.
+3. Edit `.env` with your tokens and IDs.
+
+## Running as Windows Service
+1. Install [nssm](https://nssm.cc/).
+2. Register the service:
+   ```cmd
+   nssm install SaaSService "C:\path\to\venv\Scripts\python.exe" "C:\repo\SaaS.py"
+   ```
+3. Start the service via `nssm start SaaSService`.
+
+## GitHub Actions
+`deploy.yml` runs the script on every push to `main`. Secrets for tokens and the Google service account JSON should be stored in the repository secrets.
+
+## Tests
+Run `pytest` to execute the unit tests.
+

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Activate virtual environment and run SaaS
+
+if not exist venv (
+    python -m venv venv
+)
+
+call venv\Scripts\activate
+pip install -r requirements.txt
+
+if not exist .env (
+    copy .env.example .env
+)
+
+python SaaS.py
+pause
+

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -7,14 +7,19 @@ import SaaS
 
 @pytest.mark.asyncio
 async def test_trip_date_parsing():
-    # 직원목록 더미 방지(people_list 파라미터 제거)
-    with patch.object(SaaS, 'notion', autospec=True) as mock_create:
-        mock_create.pages.create = MagicMock()
-        await SaaS.create_dummy_data('db_id', '출장 요청서')
+    """출장 요청 더미 데이터 생성 시 날짜 파싱 검증"""
+    with patch.object(SaaS, "notion") as mock_notion:
+        mock_notion.pages.create = MagicMock()
+        mock_notion.databases.retrieve.return_value = {
+            "properties": {"상태": {"type": "status"}}
+        }
+
+        await SaaS.create_dummy_data("db_id", "출장 요청서")
+
         # 더미 5건 생성되는지
-        assert mock_create.call_count == 5
+        assert mock_notion.pages.create.call_count == 5
         # 첫 호출의 날짜 파싱 확인
-        first_call = mock_create.call_args_list[0]
-        props = first_call.kwargs['properties']
-        assert props['출장기간']['date']['start'] == '2024-06-01'
-        assert props['출장기간']['date']['end'] == '2024-06-05'
+        first_call = mock_notion.pages.create.call_args_list[0]
+        props = first_call.kwargs["properties"]
+        assert props["출장기간"]["date"]["start"] == "2024-06-01"
+        assert props["출장기간"]["date"]["end"] == "2024-06-05"


### PR DESCRIPTION
## Summary
- improve `tests/test_dummy_data.py` mocking notion behavior
- add example environment file
- create Windows setup script
- include simple Google Calendar helpers and Slack error alerts
- add GitHub Actions workflow for automation
- update README with setup and service instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844306aa5f08324b73fcc49e8d862e5